### PR TITLE
Unicode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,22 @@
 ```go
 func LoadFont(file string, scale int32, windowWidth int, windowHeight int) (*Font, error)
 ```
-LoadFont loads the specified font at the given scale.
+LoadFont loads the specified font at the given scale. The default character set
+is ASCII (codepoints 32 to 127).
 
 #### func  LoadTrueTypeFont
 
 ```go
 func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, dir Direction) (*Font, error)
 ```
-LoadTrueTypeFont builds a set of textures based on a ttf files gylphs
+LoadTrueTypeFont builds buffers and textures based on a ttf files gylphs.
+
+#### func (*Font) GenerateGlyphs
+
+```go
+func (f *Font) GenerateGlyphs(low, high rune) error
+```
+GenerateGlyphs builds additional glyphs for non-ASCII Unicode codepoints.
 
 #### func (*Font) Printf
 

--- a/font.go
+++ b/font.go
@@ -19,7 +19,7 @@ const (
 
 // A Font allows rendering of text to an OpenGL context.
 type Font struct {
-	fontChar []*character
+	fontChar map[rune]*character
 	vao      uint32
 	vbo      uint32
 	program  uint32
@@ -82,8 +82,6 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		return nil
 	}
 
-	lowChar := rune(32)
-
 	//setup blending mode
 	gl.Enable(gl.BLEND)
 	gl.BlendFunc(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA)
@@ -105,14 +103,14 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		//get rune
 		runeIndex := indices[i]
 
+		//find rune in fontChar list
+		ch, ok := f.fontChar[runeIndex]
+
 		//skip runes that are not in font chacter range
-		if int(runeIndex)-int(lowChar) > len(f.fontChar) || runeIndex < lowChar {
+		if !ok {
 			fmt.Printf("%c %d\n", runeIndex, runeIndex)
 			continue
 		}
-
-		//find rune in fontChar list
-		ch := f.fontChar[runeIndex-lowChar]
 
 		//calculate position and size for current rune
 		xpos := x + float32(ch.bearingH)*scale
@@ -165,22 +163,20 @@ func (f *Font) Width(scale float32, fs string, argv ...interface{}) float32 {
 		return 0
 	}
 
-	lowChar := rune(32)
-
 	// Iterate through all characters in string
 	for i := range indices {
 
 		//get rune
 		runeIndex := indices[i]
 
+		//find rune in fontChar list
+		ch, ok := f.fontChar[runeIndex]
+
 		//skip runes that are not in font chacter range
-		if int(runeIndex)-int(lowChar) > len(f.fontChar) || runeIndex < lowChar {
+		if !ok {
 			fmt.Printf("%c %d\n", runeIndex, runeIndex)
 			continue
 		}
-
-		//find rune in fontChar list
-		ch := f.fontChar[runeIndex-lowChar]
 
 		// Now advance cursors for next glyph (note that advance is number of 1/64 pixels)
 		width += float32((ch.advance >> 6)) * scale // Bitshift by 6 to get value in pixels (2^6 = 64 (divide amount of 1/64th pixels by 64 to get amount of pixels))

--- a/font.go
+++ b/font.go
@@ -96,6 +96,13 @@ func (f *Font) Printf(x, y float32, scale float32, fs string, argv ...interface{
 		//find rune in fontChar list
 		ch, ok := f.fontChar[runeIndex]
 
+		//load missing runes in batches of 32
+		if !ok {
+			low := runeIndex - (runeIndex % 32)
+			f.GenerateGlyphs(low, low + 31)
+			ch, ok = f.fontChar[runeIndex]
+		}
+
 		//skip runes that are not in font chacter range
 		if !ok {
 			fmt.Printf("%c %d\n", runeIndex, runeIndex)
@@ -161,6 +168,13 @@ func (f *Font) Width(scale float32, fs string, argv ...interface{}) float32 {
 
 		//find rune in fontChar list
 		ch, ok := f.fontChar[runeIndex]
+
+		//load missing runes in batches of 32
+		if !ok {
+			low := runeIndex & rune(32 - 1)
+			f.GenerateGlyphs(low, low + 31)
+			ch, ok = f.fontChar[runeIndex]
+		}
 
 		//skip runes that are not in font chacter range
 		if !ok {

--- a/font.go
+++ b/font.go
@@ -17,16 +17,6 @@ const (
 	TopToBottom                  // E.g.: Chinese
 )
 
-// A Font allows rendering of text to an OpenGL context.
-type Font struct {
-	fontChar map[rune]*character
-	vao      uint32
-	vbo      uint32
-	program  uint32
-	texture  uint32 // Holds the glyph texture id.
-	color    color
-}
-
 type color struct {
 	r float32
 	g float32

--- a/truetype.go
+++ b/truetype.go
@@ -108,7 +108,7 @@ func GenerateGlyphs(f *Font, ttf *truetype.Font, scale int32, low, high rune) er
 		char.textureID = texture
 
 		//add char to fontChar list
-		f.fontChar = append(f.fontChar, char)
+		f.fontChar[ch] = char
 	}
 
 	gl.BindTexture(gl.TEXTURE_2D, 0)
@@ -130,7 +130,7 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 
 	//make Font stuct type
 	f := new(Font)
-	f.fontChar = make([]*character, 0, high-low+1)
+	f.fontChar = make(map[rune]*character)
 	f.program = program            //set shader program
 	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
 

--- a/truetype.go
+++ b/truetype.go
@@ -22,46 +22,35 @@ type character struct {
 	bearingV  int    //glyph bearing vertical
 }
 
-//LoadTrueTypeFont builds a set of textures based on a ttf files gylphs
-func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, dir Direction) (*Font, error) {
-	data, err := ioutil.ReadAll(r)
-	if err != nil {
-		return nil, err
-	}
+//GenerateGlyphs builds a set of textures based on a ttf files gylphs
+func GenerateGlyphs(f *Font, ttf *truetype.Font, scale int32, low, high rune) error {
+	//create a freetype context for drawing
+	c := freetype.NewContext()
+	c.SetDPI(72)
+	c.SetFont(ttf)
+	c.SetFontSize(float64(scale))
+	c.SetHinting(font.HintingFull)
 
-	// Read the truetype font.
-	ttf, err := truetype.Parse(data)
-	if err != nil {
-		return nil, err
-	}
-
-	//make Font stuct type
-	f := new(Font)
-	f.fontChar = make([]*character, 0, high-low+1)
-	f.program = program            //set shader program
-	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
+	//create new face to measure glyph dimensions
+	ttfFace := truetype.NewFace(ttf, &truetype.Options{
+		Size:    float64(scale),
+		DPI:     72,
+		Hinting: font.HintingFull,
+	})
 
 	//make each gylph
 	for ch := low; ch <= high; ch++ {
-
 		char := new(character)
-
-		//create new face to measure glyph diamensions
-		ttfFace := truetype.NewFace(ttf, &truetype.Options{
-			Size:    float64(scale),
-			DPI:     72,
-			Hinting: font.HintingFull,
-		})
 
 		gBnd, gAdv, ok := ttfFace.GlyphBounds(ch)
 		if ok != true {
-			return nil, fmt.Errorf("ttf face glyphBounds error")
+			return fmt.Errorf("ttf face glyphBounds error")
 		}
 
 		gh := int32((gBnd.Max.Y - gBnd.Min.Y) >> 6)
 		gw := int32((gBnd.Max.X - gBnd.Min.X) >> 6)
 
-		//if gylph has no diamensions set to a max value
+		//if gylph has no dimensions set to a max value
 		if gw == 0 || gh == 0 {
 			gBnd = ttf.Bounds(fixed.Int26_6(scale))
 			gw = int32((gBnd.Max.X - gBnd.Min.X) >> 6)
@@ -91,25 +80,18 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 		rgba := image.NewRGBA(rect)
 		draw.Draw(rgba, rgba.Bounds(), bg, image.ZP, draw.Src)
 
-		//create a freetype context for drawing
-		c := freetype.NewContext()
-		c.SetDPI(72)
-		c.SetFont(ttf)
-		c.SetFontSize(float64(scale))
-		c.SetClip(rgba.Bounds())
-		c.SetDst(rgba)
-		c.SetSrc(fg)
-		c.SetHinting(font.HintingFull)
-
 		//set the glyph dot
 		px := 0 - (int(gBnd.Min.X) >> 6)
 		py := (gAscent)
 		pt := freetype.Pt(px, py)
 
 		// Draw the text from mask to image
-		_, err = c.DrawString(string(ch), pt)
+		c.SetClip(rgba.Bounds())
+		c.SetDst(rgba)
+		c.SetSrc(fg)
+		_, err := c.DrawString(string(ch), pt)
 		if err != nil {
-			return nil, err
+			return err
 		}
 
 		// Generate texture
@@ -127,10 +109,35 @@ func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, 
 
 		//add char to fontChar list
 		f.fontChar = append(f.fontChar, char)
-
 	}
 
 	gl.BindTexture(gl.TEXTURE_2D, 0)
+	return nil
+}
+
+//LoadTrueTypeFont builds OpenGL buffers and glyph textures based on a ttf file
+func LoadTrueTypeFont(program uint32, r io.Reader, scale int32, low, high rune, dir Direction) (*Font, error) {
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the truetype font.
+	ttf, err := truetype.Parse(data)
+	if err != nil {
+		return nil, err
+	}
+
+	//make Font stuct type
+	f := new(Font)
+	f.fontChar = make([]*character, 0, high-low+1)
+	f.program = program            //set shader program
+	f.SetColor(1.0, 1.0, 1.0, 1.0) //set default white
+
+	err = GenerateGlyphs(f, ttf, scale, low, high)
+	if err != nil {
+		return nil, err
+	}
 
 	// Configure VAO/VBO for texture quads
 	gl.GenVertexArrays(1, &f.vao)


### PR DESCRIPTION
Hi! This PR extends the API to allow Unicode rendering, by adding a new `GenerateGlyphs(low, high)` function.

It will require minor tweaks to Ikemen GO, but this is the first step. I also [submitted it to upstream](https://github.com/nullboundary/glfont/pull/13).