### PR TITLE
Update: macOS build changed to GL 3.2 builds for all instead

### DIFF
--- a/font.go
+++ b/font.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !gl32
 
 package glfont
 

--- a/font_gl32.go
+++ b/font_gl32.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build gl32
 
 package glfont
 

--- a/shader.go
+++ b/shader.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !gl32
 
 package glfont
 

--- a/shader_gl32.go
+++ b/shader_gl32.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build gl32
 
 package glfont
 

--- a/truetype.go
+++ b/truetype.go
@@ -1,4 +1,4 @@
-//go:build !darwin
+//go:build !gl32
 
 package glfont
 

--- a/truetype_gl32.go
+++ b/truetype_gl32.go
@@ -1,4 +1,4 @@
-//go:build darwin
+//go:build gl32
 
 package glfont
 


### PR DESCRIPTION
This changes the macOS build to allow for a general GL 3.2 build for Windows and Linux 64-bit in addition to the current macOS build